### PR TITLE
Address build/render issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 node_modules
 dist
+test/__screenshots__
 
 *.log
 .DS_Store
 .eslintcache
 .direnv
+.idea

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vitest-browser-qwik",
 	"version": "0.0.6",
 	"packageManager": "pnpm@10.11.0",
-	"description": "A starter for creating a tsdown package.",
+	"description": "Render Qwik components using Vitest Browser Mode",
 	"type": "module",
 	"license": "MIT",
 	"homepage": "https://github.com/kunai-consulting/vitest-browser-qwik#readme",
@@ -15,14 +15,22 @@
 	},
 	"author": "Kunai Consulting <kunaico.com>",
 	"files": [
-		"dist"
+	  "*.d.ts",
+	  "*.mjs",
+	  "dist"
 	],
 	"main": "./dist/index.js",
 	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"exports": {
-		".": "./dist/index.js",
-		"./package.json": "./package.json"
+	  ".": {
+		"types": "./dist/index.d.ts",
+		"default": "./dist/index.js"
+	  },
+	  "./pure": {
+		"types": "./dist/pure.d.ts",
+		"default": "./dist/pure.js"
+	  }
 	},
 	"publishConfig": {
 		"access": "public"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
 		"release": "bumpp && pnpm publish",
 		"prepublishOnly": "pnpm run build"
 	},
+	"peerDependencies": {
+		"@builder.io/qwik": "^1.14.1",
+		"@vitest/browser": "^3.2.4",
+		"vitest": "^3.1.3"
+	},
 	"devDependencies": {
 		"@biomejs/biome": "2.0.0",
 		"@builder.io/qwik": "1.14.1",

--- a/src/pure.tsx
+++ b/src/pure.tsx
@@ -46,7 +46,6 @@ function createRenderResult(
 	container: HTMLElement,
 	baseElement: HTMLElement,
 ): RenderResult {
-	console.log("createRenderResult -- calling mountedContainers.add");
 	mountedContainers.add(container);
 
 	const unmount = () => {
@@ -75,37 +74,27 @@ function setupContainer(
 	baseElement?: HTMLElement,
 	container?: HTMLElement,
 ): { container: HTMLElement; baseElement: HTMLElement } {
-	console.log("setupContainer inputs", { baseElement, container });
 	if (!baseElement) {
-		console.log("setupContainer -- baseElement is undefined");
 		baseElement = document.body;
 	}
 
-	console.log("setupContainer -- calling document.createElement");
 	if (!container) {
 		container = baseElement.appendChild(document.createElement("div"));
 	}
 
-	console.log("setupContainer -- returning");
 	return { container, baseElement };
 }
 
-export async function render(
+export function render(
 	ui: JSXOutput,
 	{ container, baseElement }: RenderOptions = {},
-): Promise<RenderResult> {
-	console.log("render -- calling csrQwikLoader");
+): RenderResult {
 	csrQwikLoader();
 
-	console.log("render -- calling setupContainer");
 	const setup = setupContainer(baseElement, container);
-	console.log("setupContainer result", setup);
-	console.log("render -- calling qwikRender");
-	await qwikRender(setup.container, ui);
-	console.log("render -- calling createRenderResult");
-	const renderResult = createRenderResult(setup.container, setup.baseElement);
-	console.log("renderResult", renderResult);
-	return renderResult;
+	qwikRender(setup.container, ui);
+
+	return createRenderResult(setup.container, setup.baseElement);
 }
 
 function setHTMLWithScripts(container: HTMLElement, html: string) {

--- a/src/pure.tsx
+++ b/src/pure.tsx
@@ -46,6 +46,7 @@ function createRenderResult(
 	container: HTMLElement,
 	baseElement: HTMLElement,
 ): RenderResult {
+	console.log("createRenderResult -- calling mountedContainers.add");
 	mountedContainers.add(container);
 
 	const unmount = () => {
@@ -74,27 +75,37 @@ function setupContainer(
 	baseElement?: HTMLElement,
 	container?: HTMLElement,
 ): { container: HTMLElement; baseElement: HTMLElement } {
+	console.log("setupContainer inputs", { baseElement, container });
 	if (!baseElement) {
+		console.log("setupContainer -- baseElement is undefined");
 		baseElement = document.body;
 	}
 
+	console.log("setupContainer -- calling document.createElement");
 	if (!container) {
 		container = baseElement.appendChild(document.createElement("div"));
 	}
 
+	console.log("setupContainer -- returning");
 	return { container, baseElement };
 }
 
-export function render(
+export async function render(
 	ui: JSXOutput,
 	{ container, baseElement }: RenderOptions = {},
-): RenderResult {
+): Promise<RenderResult> {
+	console.log("render -- calling csrQwikLoader");
 	csrQwikLoader();
 
+	console.log("render -- calling setupContainer");
 	const setup = setupContainer(baseElement, container);
-	qwikRender(setup.container, ui);
-
-	return createRenderResult(setup.container, setup.baseElement);
+	console.log("setupContainer result", setup);
+	console.log("render -- calling qwikRender");
+	await qwikRender(setup.container, ui);
+	console.log("render -- calling createRenderResult");
+	const renderResult = createRenderResult(setup.container, setup.baseElement);
+	console.log("renderResult", renderResult);
+	return renderResult;
 }
 
 function setHTMLWithScripts(container: HTMLElement, html: string) {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,9 +1,9 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	entry: ["./src/index.ts", "./src/pure.ts"],
+	entry: ["./src/index.ts", "./src/pure.tsx"],
 	format: ["esm"],
 	dts: true,
 	platform: "browser",
-	external: ["@vitest/browser/utils", "vitest"],
+	external: ["@vitest/browser/context", "@vitest/browser/utils", "vitest"],
 });

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,5 +5,11 @@ export default defineConfig({
 	format: ["esm"],
 	dts: true,
 	platform: "browser",
-	external: ["@vitest/browser/context", "@vitest/browser/utils", "vitest"],
+	external: [
+		"@builder.io/qwik",
+		"@builder.io/qwik/server",
+		"@vitest/browser/context", 
+		"@vitest/browser/utils", 
+		"vitest"
+	],
 });


### PR DESCRIPTION
# Problem Description
In the built version of the library, `render` is failing to render anything beyond an empty div:
```
<div
q:container="resumed"
q:render="dom"
q:version="1.14.1"
/>
```

This method works fine in the `@file:render.test.tsx` with output like this:
```
<div
q:container="resumed"
q:render="dom"
q:version="1.14.1"
>
<!--qv -->
<div>
Hello World
</div>
<!--/qv-->
</div>
```
But we need the built/consumed version of the library to render properly as well.

# Solution
The main fix here is to externalize Qwik-related dependencies and let the consuming project handle them.

## Other
- Set vitest and qwik as peer dependencies
- Update to package.json to look more like other similar libraries in terms of files, entry, and description
- Minor updates to .gitignore

